### PR TITLE
feat: add support for sentry session replays

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -3,10 +3,10 @@
 ## Publishing a new release
 
 ```
-docker build --tag sentry_tunnel:latest . # Build docker image
+docker build --tag ghcr.io/flusinerd/sentry_tunnel:latest . # Build docker image
 #docker image ls | grep sentry # Find image ID
 #docker tag <ID> sigalen/sentry_tunnel:latest # Create image tag (in case of build fail)
-docker push sigalen/sentry_tunnel:latest
+docker push ghcr.io/flusinerd/sentry_tunnel:latest
 ```
 
 ## Building for a different architecture

--- a/DEV.md
+++ b/DEV.md
@@ -3,10 +3,10 @@
 ## Publishing a new release
 
 ```
-docker build --tag ghcr.io/flusinerd/sentry_tunnel:latest . # Build docker image
+docker build --tag sentry_tunnel:latest . # Build docker image
 #docker image ls | grep sentry # Find image ID
 #docker tag <ID> sigalen/sentry_tunnel:latest # Create image tag (in case of build fail)
-docker push ghcr.io/flusinerd/sentry_tunnel:latest
+docker push sigalen/sentry_tunnel:latest
 ```
 
 ## Building for a different architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN cp ./target/${ARCH}-unknown-linux-musl/release/sentry_tunnel /release/sentry
 #===========================#
 # Install ssl certificates  #
 #===========================#
-FROM alpine:3.14 as alpine
+FROM alpine:3.14 AS alpine
 RUN apk add -U --no-cache ca-certificates
 
 # ==========================#

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,7 +37,7 @@ struct TunnelConfig {
     inner: Arc<Config>,
 }
 
-fn parse_body(body: String) -> Result<SentryEnvelope, AError> {
+fn parse_body(body: Vec<u8>) -> Result<SentryEnvelope, AError> {
     SentryEnvelope::try_new_from_body(body)
 }
 
@@ -102,8 +102,7 @@ async fn tunnel_handler(state: &mut State) -> Result<Response<Body>, AError> {
     check_content_length(&headers)?;
 
     let full_body = body::to_bytes(Body::take_from(state)).await?;
-    let body_content = String::from_utf8(full_body.to_vec())?;
-    let sentry_instance = parse_body(body_content)?;
+    let sentry_instance = parse_body(full_body.to_vec())?;
 
     let config = TunnelConfig::borrow_from(state);
     let hosts = &config.inner.remote_hosts;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -56,6 +56,58 @@ mod tests {
     }
 
     #[test]
+    fn test_session_replay_envelope() {
+        let server = MockServer::start();
+        let sentry_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/6/envelope/");
+            then.status(200);
+        });
+        let test_config = Config {
+            remote_hosts: Config::clean_remote_hosts(&[server.url("")]),
+            project_ids: vec!["6".to_string()],
+            port: 7878,
+            tunnel_path: "/tunnel".to_string(),
+            ip: "0.0.0.0".to_string(),
+        };
+        let test_server = TestServer::new(router(
+            &test_config.tunnel_path.clone(),
+            test_config.clone(),
+        ))
+        .unwrap();
+        
+        // Session replay envelope with multiple lines (header + multiple items)
+        let json = r#"{"event_id":"65de0c6c634c4b29b63eb2af58e7bfa7","sent_at":"2025-07-09T21:52:36.839Z","sdk":{"name":"sentry.javascript.react","version":"9.24.0"},"dsn":"http://public@HOST_TEST_REPLACE/6"}
+{"type":"replay_event"}
+{"type":"replay_event","replay_start_timestamp":1752097947.846,"timestamp":1752097956.838,"error_ids":["a11c57d12066461982ff3fbb78ab0752"],"trace_ids":["836b56305ed84493a72b4a4f58cba356","c8fd251f22884313a09208497f1f3753"],"urls":["https://my.langguth.com/shop/customers/4285ff71-028d-4755-850c-090f520695b8/machines/ec19bb09-374e-4ace-ab26-2ae246f82ce9"],"replay_id":"65de0c6c634c4b29b63eb2af58e7bfa7","segment_id":0,"replay_type":"buffer","request":{"url":"https://my.langguth.com/shop/customers/4285ff71-028d-4755-850c-090f520695b8/machines/ec19bb09-374e-4ace-ab26-2ae246f82ce9","headers":{"User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"}},"event_id":"65de0c6c634c4b29b63eb2af58e7bfa7","environment":"production","release":"1.9.1","sdk":{"integrations":["InboundFilters","FunctionToString","BrowserApiErrors","Breadcrumbs","GlobalHandlers","LinkedErrors","Dedupe","HttpContext","BrowserSession","BrowserTracing","Replay","RewriteFrames"],"name":"sentry.javascript.react","version":"9.24.0"},"contexts":{"react":{"version":"19.0.0"}},"transaction":"/customers/$customerId/machines/$machineId","user":{"ip_address":"{{auto}}"},"platform":"javascript"}
+{"type":"replay_recording","length":57959}
+{"segment_id":0}
+binary_data_placeholder"#;
+        
+        let json = json
+            .replace("HOST_TEST_REPLACE", &server.address().to_string())
+            .to_owned();
+        println!("{:?}", json);
+        
+        let mime = "application/json".parse::<Mime>().unwrap();
+        let response = test_server
+            .client()
+            .post(
+                "http://localhost".to_owned() + &test_config.tunnel_path,
+                json.clone(),
+                mime,
+            )
+            .with_header(
+                header::CONTENT_LENGTH,
+                HeaderValue::from_str(&format!("{}", json.as_bytes().len())).unwrap(),
+            )
+            .perform()
+            .unwrap();
+
+        sentry_mock.assert();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
     fn test_invalid_project_id() {
         let test_config = Config {
             remote_hosts: vec![Host("https://sentry.example.com/".to_string())],
@@ -168,6 +220,80 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response.read_body().unwrap();
         let expc = format!("{}", HeaderError::InvalidHost);
+
+        assert_eq!(String::from_utf8(body).unwrap(), expc);
+    }
+
+    #[test]
+    fn test_empty_body() {
+        let test_config = Config {
+            remote_hosts: vec![Host("https://sentry.example.com/".to_string())],
+            project_ids: vec!["5".to_string()],
+            port: 7878,
+            tunnel_path: "/tunnel".to_string(),
+            ip: "0.0.0.0".to_string(),
+        };
+        let test_server = TestServer::new(router(
+            &test_config.tunnel_path.clone(),
+            test_config.clone(),
+        ))
+        .unwrap();
+        let json = "";
+        let mime = "application/json".parse::<Mime>().unwrap();
+        let response = test_server
+            .client()
+            .post(
+                "http://localhost".to_owned() + &test_config.tunnel_path,
+                json,
+                mime,
+            )
+            .with_header(
+                header::CONTENT_LENGTH,
+                HeaderValue::from_str(&format!("{}", json.as_bytes().len())).unwrap(),
+            )
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.read_body().unwrap();
+        let expc = format!("{}", BodyError::EmptyBody);
+
+        assert_eq!(String::from_utf8(body).unwrap(), expc);
+    }
+
+    #[test]
+    fn test_insufficient_lines() {
+        let test_config = Config {
+            remote_hosts: vec![Host("https://sentry.example.com/".to_string())],
+            project_ids: vec!["5".to_string()],
+            port: 7878,
+            tunnel_path: "/tunnel".to_string(),
+            ip: "0.0.0.0".to_string(),
+        };
+        let test_server = TestServer::new(router(
+            &test_config.tunnel_path.clone(),
+            test_config.clone(),
+        ))
+        .unwrap();
+        let json = r#"{"sent_at":"2021-10-14T17:10:40.136Z","sdk":{"name":"sentry.javascript.browser","version":"6.13.3"},"dsn":"https://public@sentry.example.com/5"}"#;
+        let mime = "application/json".parse::<Mime>().unwrap();
+        let response = test_server
+            .client()
+            .post(
+                "http://localhost".to_owned() + &test_config.tunnel_path,
+                json,
+                mime,
+            )
+            .with_header(
+                header::CONTENT_LENGTH,
+                HeaderValue::from_str(&format!("{}", json.as_bytes().len())).unwrap(),
+            )
+            .perform()
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.read_body().unwrap();
+        let expc = format!("{}", BodyError::InvalidNumberOfLines);
 
         assert_eq!(String::from_utf8(body).unwrap(), expc);
     }


### PR DESCRIPTION
This adds support for replay event tunneling.
Currently this fails with a 400 error because of different amount of lines.

Also the final line is non utf-8 binary data.